### PR TITLE
Split separate files with overlapping ids

### DIFF
--- a/corpus2alpino/__main__.py
+++ b/corpus2alpino/__main__.py
@@ -49,12 +49,12 @@ def main(args=None):
             help='Output format: can be lassy, paqu (default)'
         )
         parser.add_argument(
-            '-p', '--progress', metavar="BOOL", type=bool,
+            '-p', '--progress',
+            action='store_true',
             help='Show progress bar, automatically turned on file output')
-        parser.add_argument('-t', '--split_treebanks', action='store_true',
+        parser.add_argument('-t', '--split_treebanks',
+                            action='store_true',
                             help='Split treebanks to separate files')
-
-        parser.set_defaults(split_treebanks=False)
 
         # passthrough the subprocess arguments
         subprocess = None
@@ -80,7 +80,7 @@ def main(args=None):
                     AlpinoAnnotator(executable, arguments))
 
             converter.writer = LassyWriter(not options.split_treebanks)
-        
+
         if options.enrichment != None:
             converter.annotators.append(EnrichLassyAnnotator(options.enrichment))
 

--- a/corpus2alpino/targets/filesystem.py
+++ b/corpus2alpino/targets/filesystem.py
@@ -29,13 +29,16 @@ class FilesystemTarget(Target):
                 output_path = str(
                     Path(output_path).with_suffix(cast(str, suffix)))
 
-            if self.__current_output_path != output_path:
-                if self.file:  # type: ignore
-                    self.file.close()  # type: ignore
-                self.__current_output_path = output_path  # type: ignore
-                directory, filename = path.split(output_path)
-                makedirs(directory, exist_ok=True)
-                self.file = self.__open_unique(directory, filename)
+            # always open a new file when splitting in separate files
+            self.__current_output_path = None
+
+        if self.__current_output_path != output_path:
+            if self.file:  # type: ignore
+                self.file.close()  # type: ignore
+            self.__current_output_path = output_path  # type: ignore
+            directory, filename = path.split(output_path)
+            makedirs(directory, exist_ok=True)
+            self.file = self.__open_unique(directory, filename)
 
     def __open_unique(self, directory: str, filename: str):
         attempts = 0


### PR DESCRIPTION
Paqu-files without (utt)id ended up merged into a single invalid file